### PR TITLE
Handling TCC metric Nan result

### DIFF
--- a/fixtures/ClassCohesion/OneVisibleMethod.java
+++ b/fixtures/ClassCohesion/OneVisibleMethod.java
@@ -1,0 +1,9 @@
+package ClassCohesion;
+
+class OneVisibleMethod {
+	private static int a = 10;
+
+	public void m1() { a = 10; }
+
+	private void m2() { a = 20; }
+}

--- a/src/main/java/com/github/mauricioaniche/ck/metric/TightClassCohesion.java
+++ b/src/main/java/com/github/mauricioaniche/ck/metric/TightClassCohesion.java
@@ -113,7 +113,7 @@ public class TightClassCohesion implements CKASTVisitor, ClassLevelMetric {
 
     public void setResult(CKClassResult result) {
         //in case the class does not contain any visible methods, TCC and LCC have no reasonable value, thus set it to -1
-        if(result.getVisibleMethods().size() < 1){
+        if(result.getVisibleMethods().size() < 2){
             result.setTightClassCohesion(-1);
             result.setLooseClassCohesion(-1);
         } else {

--- a/src/test/java/com/github/mauricioaniche/ck/BaseTest.java
+++ b/src/test/java/com/github/mauricioaniche/ck/BaseTest.java
@@ -7,6 +7,8 @@ import org.junit.jupiter.api.Test;
 
 import java.io.File;
 import java.io.IOException;
+import java.net.URLDecoder;
+import java.nio.charset.StandardCharsets;
 import java.util.*;
 import java.util.concurrent.Callable;
 
@@ -19,7 +21,7 @@ public abstract class BaseTest {
 	protected static String fixturesDir() {
 		try {
 			String cfgFile = new File(BaseTest.class.getResource("/").getPath() + "../../fixtures/").getCanonicalPath();
-			return cfgFile;
+			return URLDecoder.decode(cfgFile, StandardCharsets.UTF_8);
 		} catch (IOException e) {
 			throw new RuntimeException(e);
 		}

--- a/src/test/java/com/github/mauricioaniche/ck/TightClassCohesionTest.java
+++ b/src/test/java/com/github/mauricioaniche/ck/TightClassCohesionTest.java
@@ -23,6 +23,12 @@ public class TightClassCohesionTest extends BaseTest {
     }
 
     @Test
+    public void negativeCohesion() {
+        CKClassResult ckClass = report.get("ClassCohesion.OneVisibleMethod");
+        assertEquals(-1, ckClass.getTightClassCohesion(),0.0000001);
+    }
+
+    @Test
     public void noCohesion() {
         CKClassResult ckClass = report.get("ClassCohesion.NoCohesion");
         assertEquals(0f, ckClass.getTightClassCohesion(),0.0000001);


### PR DESCRIPTION
Modify TCC metric to return -1 instead of Nan if a class has only one visible method

- Condition for the -1 error value changed to _number of visible methods < 2_
- Test case and test class were created 